### PR TITLE
feat/task-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <br/>
   <h2>Solid on Rails</h2>
   <p>
-    A web-application framework for building highly configurable & decentralized apps <br/> using <a href="https://nodejs.org/">Node.js</a>, <a href="https://www.comake.io/skl">SKL</a>, and <a href="https://solidproject.org/">Solid</a>.
+    A web-application framework for building highly configurable & decentralized apps <br/> using <a href="https://nodejs.org/">Node.js</a> and <a href="https://solidproject.org/">Solid</a>.
   </p>
   <p>
     <a href="#features"><strong>Features</strong></a> ·

--- a/config/example-task-accessor.json
+++ b/config/example-task-accessor.json
@@ -1,0 +1,43 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comake/solid-on-rails/^0.0.0/components/context.jsonld",
+  "import": [
+    "files-sor:config/app/main/default.json",
+    "files-sor:config/app/initialize/no-server.json",
+    "files-sor:config/app/finalize/no-server.json",
+    "files-sor:config/app/variables/default.json",
+    "files-sor:config/app/path/default.json",
+
+    "files-sor:config/storage/key-value/memory.json",
+    "files-sor:config/storage/data-mapper/type-orm.json",
+
+    "files-sor:config/jobs/bull.json",
+
+    "files-sor:config/util/variables/default.json",
+    "files-sor:config/util/logging/winston.json"
+  ],
+  "@graph": [
+    {
+      "comment": "Access to the Data Mapper and Key Value storages.",
+      "@id": "urn:solid-on-rails:queue-accessor:Instances",
+      "@type": "RecordObject",
+      "record": [
+        {
+          "RecordObject:_record_key": "app",
+          "RecordObject:_record_value": { "@id": "urn:solid-on-rails:default:App" }
+        },
+        {
+          "RecordObject:_record_key": "dataMapper",
+          "RecordObject:_record_value": { "@id": "urn:solid-on-rails:default:DataMapper" }
+        },
+        {
+          "RecordObject:_record_key": "keyValue",
+          "RecordObject:_record_value": { "@id": "urn:solid-on-rails:default:KeyValueStorage" }
+        },
+        {
+          "RecordObject:_record_key": "queueAdapter",
+          "RecordObject:_record_value": { "@id": "urn:solid-on-rails:default:QueueAdapter" }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -142,8 +142,9 @@ Command-line arguments will always override environment variables!
 
 Solid on Rails comes with a built in CLI which supports:
 
-* `solid-on-rails storage:seed` Seeding data into the database
-* `solid-on-rails storage:drop` Dropping all data in the database
+* `solid-on-rails task` Running a task with access to the database, key value storage, and job queues
+* `solid-on-rails storages:seed` Seeding data into the database
+* `solid-on-rails storages:drop` Dropping all data in the database
 * `solid-on-rails db:setup' Running migrations against data in the database
 * `solid-on-rails db:migrate' Running migrations against data in the database
 * `solid-on-rails db:revert` Reverting migrations
@@ -155,6 +156,7 @@ You may prefer to add helpers in your `package.json` to set the configuration op
   {
     ...
     "scripts": {
+      "task": "npx solid-on-rails task -c ./config/task-accessor.json -m .",
       "storages:seed": "npx solid-on-rails storages:seed -c ./config/storage-accessor.json -m .",
       "storages:drop": "npx solid-on-rails storages:drop -c ./config/storage-accessor.json -m .",
       "db:setup": "npx solid-on-rails db:setup -c ./config/storage-accessor.json -m .",

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -10,6 +10,7 @@ import { createErrorMessage } from '../util/errors/ErrorUtil';
 import { resolveModulePath } from '../util/PathUtil';
 import { QueueAdapterAccessorRunner } from './QueueAdapterAccessorRunner';
 import { StorageAccessorRunner } from './StorageAccessorRunner';
+import { TaskRunner } from './TaskRunner';
 
 // See https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
 dotenv.config();
@@ -66,6 +67,7 @@ export class Cli {
     // Parse the core CLI arguments needed to load the configuration
     const yargv = yargs(argv.slice(2))
       .usage('solid-on-rails [<command>]')
+      .command('task', 'Run a task from the tasks folder')
       .command('storages:seed', 'Seed the storages from the ./db/seeds.js file')
       .command('storages:drop', 'Drop all data from the DataMapper and KeyValue Storages')
       .command('db:setup', 'Setup the database from configured entity schemas')
@@ -90,6 +92,10 @@ export class Cli {
     if (!command) {
       const appRunner = new AppRunner();
       return appRunner.runCli(params, argv);
+    }
+    if (command === 'task') {
+      const runner = new TaskRunner();
+      return runner.runTask(params, argv);
     }
     if (command === 'storages:seed') {
       const runner = new StorageAccessorRunner();

--- a/src/cli/TaskRunner.ts
+++ b/src/cli/TaskRunner.ts
@@ -1,0 +1,32 @@
+/* eslint-disable
+  global-require,
+  @typescript-eslint/no-require-imports,
+  @typescript-eslint/no-var-requires
+*/
+import type { CliArgv } from '../init/variables/Types';
+import { getLoggerFor } from '../logging/LogUtil';
+import type { CliParameters } from '../util/ComponentsJsUtil';
+import { absoluteFilePath } from '../util/PathUtil';
+import type { AsyncronousAppRunnerCallbackArgs } from './AsyncronousAppAccessorRunner';
+import { AsyncronousAppAccessorRunner } from './AsyncronousAppAccessorRunner';
+
+/**
+ * A class that can be used to instantiate and start a server based on a Component.js configuration.
+ */
+export class TaskRunner extends AsyncronousAppAccessorRunner {
+  protected readonly instantiationErrorMessage = 'Could not create the storages';
+  protected readonly defaultInstancesUri = 'urn:solid-on-rails:storage-accessor:Instances';
+  protected readonly logger = getLoggerFor(this);
+
+  public async runTask(params: CliParameters, argv: CliArgv): Promise<void> {
+    const callback = async(args: AsyncronousAppRunnerCallbackArgs): Promise<void> => {
+      const taskName = argv[2];
+      this.logger.info(`Running task ${taskName}`);
+      const taskFile = absoluteFilePath(`./tasks/${taskName}.js`);
+      const taskFunction = require(taskFile);
+      await taskFunction(args);
+      this.logger.info('Successfully executed task');
+    };
+    await this.runAppAndExecuteCallbackWithInstancesAndEnv(params, argv, callback);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export * from './cli/AsyncronousAppAccessorRunner';
 export * from './cli/Cli';
 export * from './cli/QueueAdapterAccessorRunner';
 export * from './cli/StorageAccessorRunner';
+export * from './cli/TaskRunner';
 
 // Init/Cli
 export * from './init/cli/CliExtractor';

--- a/test/unit/cli/Cli.test.ts
+++ b/test/unit/cli/Cli.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../../src/init/AppRunner');
 
 const HELP_MESSAGE = `solid-on-rails [<command>]
     Commands:
+      script task              Run a task from the tasks folder
       script storages:seed     Seed the storages from the ./db/seeds.js file
       script storages:drop     Drop all data from the DataMapper and KeyValue Storages
       script db:setup          Setup the database from configured entity schemas

--- a/test/unit/cli/TaskRunner.test.ts
+++ b/test/unit/cli/TaskRunner.test.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { ComponentsManager } from 'componentsjs';
+import { TaskRunner } from '../../../src/cli/TaskRunner';
+import type { App } from '../../../src/init/App';
+import type { CliExtractor } from '../../../src/init/cli/CliExtractor';
+import type { SettingsResolver } from '../../../src/init/variables/SettingsResolver';
+import type { QueueAdapter } from '../../../src/jobs/adapter/QueueAdapter';
+import type { TypeOrmDataMapper } from '../../../src/storage/data-mapper/TypeOrmDataMapper';
+import type { KeyValueStorage } from '../../../src/storage/keyvalue/KeyValueStorage';
+import type { CliParameters } from '../../../src/util/ComponentsJsUtil';
+import { joinFilePath } from '../../../src/util/PathUtil';
+
+const app: jest.Mocked<App> = {
+  start: jest.fn(),
+  stop: jest.fn(),
+} as any;
+
+const dataMapper: jest.Mocked<TypeOrmDataMapper> = {
+  initialize: jest.fn(),
+  dropDatabase: jest.fn(),
+  runPendingMigrations: jest.fn(),
+  revertLastMigration: jest.fn(),
+  setupDatabase: jest.fn(),
+} as any;
+
+const keyValue: jest.Mocked<KeyValueStorage<any, any>> = {
+  entries: jest.fn().mockReturnValue([[ 'key', 'value' ], [ 'key2', 'value2' ]]),
+  delete: jest.fn(),
+} as any;
+
+const queueAdapter: jest.Mocked<QueueAdapter> = {
+  deleteAllQueues: jest.fn(),
+  deleteQueue: jest.fn(),
+} as any;
+
+const instances = {
+  app,
+  dataMapper,
+  keyValue,
+  queueAdapter,
+};
+
+const defaultParameters = {
+  port: 3000,
+  logLevel: 'info',
+};
+
+const cliExtractor: jest.Mocked<CliExtractor> = {
+  handleSafe: jest.fn().mockResolvedValue(defaultParameters),
+} as any;
+
+const defaultVariables = {
+  'urn:solid-on-rails:default:variable:port': 3000,
+  'urn:solid-on-rails:default:variable:loggingLevel': 'info',
+};
+
+const settingsResolver: jest.Mocked<SettingsResolver> = {
+  handleSafe: jest.fn().mockResolvedValue(defaultVariables),
+} as any;
+
+const manager: jest.Mocked<ComponentsManager<Record<string, any>>> = {
+  instantiate: jest.fn(async(iri: string): Promise<any> => {
+    switch (iri) {
+      case 'urn:solid-on-rails-setup:default:CliResolver': return { cliExtractor, settingsResolver };
+      case 'urn:solid-on-rails:storage-accessor:Instances': return instances;
+      default: throw new Error('unknown iri');
+    }
+  }),
+  configRegistry: {
+    register: jest.fn(),
+  },
+} as any;
+
+jest.mock('componentsjs', (): any => ({
+  ComponentsManager: {
+    build: jest.fn(async(): Promise<ComponentsManager<Record<string, any>>> => manager),
+  },
+}));
+
+jest.spyOn(process, 'cwd').mockReturnValue('/var/cwd');
+
+const basicTaskFunction = jest.fn();
+jest.mock(
+  '/var/cwd/tasks/basicTask.js',
+  (): any => basicTaskFunction,
+  { virtual: true },
+);
+
+describe('TaskRunner', (): void => {
+  let params: CliParameters;
+
+  beforeEach(async(): Promise<void> => {
+    params = {
+      config: './config.json',
+      loggingLevel: 'info',
+      mainModulePath: undefined,
+      modulePathPlaceholder: '@SoR:',
+      envVarPrefix: '',
+    };
+  });
+
+  afterEach((): void => {
+    jest.clearAllMocks();
+  });
+
+  describe('runTask', (): void => {
+    it('runs the server and executes the task function.', async(): Promise<void> => {
+      const runner = new TaskRunner();
+      await expect(runner.runTask(params, [ 'node', 'script', 'basicTask' ])).resolves.toBeUndefined();
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledWith({
+        dumpErrorState: true,
+        logLevel: 'info',
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+      });
+      expect(manager.configRegistry.register).toHaveBeenCalledTimes(1);
+      expect(manager.configRegistry.register).toHaveBeenCalledWith('/var/cwd/config.json');
+      expect(manager.instantiate).toHaveBeenCalledTimes(2);
+      expect(manager.instantiate).toHaveBeenNthCalledWith(
+        1,
+        'urn:solid-on-rails-setup:default:CliResolver',
+        { variables: { 'urn:solid-on-rails:default:variable:modulePathPlaceholder': '@SoR:' }},
+      );
+      expect(cliExtractor.handleSafe).toHaveBeenCalledTimes(1);
+      expect(cliExtractor.handleSafe).toHaveBeenCalledWith({
+        argv: [ 'node', 'script', 'basicTask' ],
+        envVarPrefix: '',
+      });
+      expect(settingsResolver.handleSafe).toHaveBeenCalledTimes(1);
+      expect(settingsResolver.handleSafe).toHaveBeenCalledWith(defaultParameters);
+      expect(manager.instantiate).toHaveBeenNthCalledWith(2,
+        'urn:solid-on-rails:storage-accessor:Instances',
+        { variables: defaultVariables });
+      expect(app.start).toHaveBeenCalledTimes(1);
+      expect(basicTaskFunction).toHaveBeenCalledTimes(1);
+      expect(basicTaskFunction).toHaveBeenCalledWith({
+        instances: {
+          dataMapper,
+          keyValue,
+          queueAdapter,
+        },
+        env: params,
+      });
+      expect(app.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
- Adds a `task` command which takes the filename of a task as a cli arg and runs the function in the file, supplying the dataMapper, keyValue, and queueAdapter
- Adds `task` command to documentation