### PR TITLE
verion/0.3.0

### DIFF
--- a/config/example-queue-accessor.json
+++ b/config/example-queue-accessor.json
@@ -9,7 +9,7 @@
 
     "files-sor:config/storage/key-value/memory.json",
 
-    "files-sor:config/jobs/bull.json",
+    "files-sor:config/jobs/bull-no-processing.json",
 
     "files-sor:config/util/variables/default.json",
     "files-sor:config/util/logging/winston.json"

--- a/config/example-task-accessor.json
+++ b/config/example-task-accessor.json
@@ -10,7 +10,7 @@
     "files-sor:config/storage/key-value/memory.json",
     "files-sor:config/storage/data-mapper/type-orm.json",
 
-    "files-sor:config/jobs/bull.json",
+    "files-sor:config/jobs/bull-no-processing.json",
 
     "files-sor:config/util/variables/default.json",
     "files-sor:config/util/logging/winston.json"

--- a/config/jobs/bull-no-processing.json
+++ b/config/jobs/bull-no-processing.json
@@ -16,8 +16,8 @@
         }
       ],
       "args_queueProcessor": {
-        "@type": "BullQueueProcessor"
-      }
+        "@type": "VoidQueueProcessor"
+      },
     },
     {
       "comment": "Makes sure the queue adapter shuts down when the application needs to stop.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comake/solid-on-rails",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@comake/solid-on-rails",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "dependencies": {
         "arrayify-stream": "^2.0.0",
         "bull": "^4.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comake/solid-on-rails",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Runs a Node.js server using componentsjs preset with configurations for working with Solid.",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,11 @@ export * from './init/CliResolver';
 export * from './jobs/adapter/BullQueueAdapter';
 export * from './jobs/adapter/QueueAdapter';
 
+// Jobs/Processor
+export * from './jobs/processor/BullQueueProcessor';
+export * from './jobs/processor/QueueProcessor';
+export * from './jobs/processor/VoidQueueProcessor';
+
 // Jobs/Scheduler
 export * from './jobs/scheduler/AdapterBasedScheduler';
 export * from './jobs/scheduler/JobScheduler';

--- a/src/jobs/processor/BullQueueProcessor.ts
+++ b/src/jobs/processor/BullQueueProcessor.ts
@@ -1,0 +1,47 @@
+import type { Queue } from 'bull';
+import { getLoggerFor } from '../../logging/LogUtil';
+import type { QueueAdapter } from '../adapter/QueueAdapter';
+import type { Job } from '../Job';
+import type { QueueProcessor } from './QueueProcessor';
+
+export class BullQueueProcessor implements QueueProcessor<Queue> {
+  protected readonly logger = getLoggerFor(this);
+
+  public processJobsOnQueues(
+    queues: Record<string, Queue>,
+    jobs: Record<string, Job>,
+    queueAdapter: QueueAdapter,
+  ): void {
+    for (const queue of Object.keys(queues)) {
+      let isFirst = true;
+      for (const jobName of Object.keys(jobs)) {
+        queues[queue].process(jobName, isFirst ? 1 : 0, async(bullJob): Promise<void> =>
+          jobs[jobName].perform(bullJob.data, queueAdapter)) as any;
+        isFirst = false;
+      }
+      this.initializeQueueEvents(queues[queue]);
+    }
+  }
+
+  private initializeQueueEvents(queue: Queue): void {
+    queue.on('error', (error): void => {
+      this.logger.info(`An error occured in queue ${queue.name}: ${error.message}\n${error.stack}`);
+    });
+
+    queue.on('active', (job): void => {
+      this.logger.info(`Job ${job.name} has started on queue ${queue.name}`);
+    });
+
+    queue.on('stalled', (job): void => {
+      this.logger.info(`Job ${job.name} has been marked as stalled on queue ${queue.name}`);
+    });
+
+    queue.on('completed', (job): void => {
+      this.logger.info(`Job ${job.name} successfully completed on queue ${queue.name}`);
+    });
+
+    queue.on('failed', (job, error): void => {
+      this.logger.info(`Job ${job.name} on queue ${queue.name} failed with reason: ${error.message}\n${error.stack}`);
+    });
+  }
+}

--- a/src/jobs/processor/QueueProcessor.ts
+++ b/src/jobs/processor/QueueProcessor.ts
@@ -1,0 +1,10 @@
+import type { QueueAdapter } from '../adapter/QueueAdapter';
+import type { Job } from '../Job';
+
+export interface QueueProcessor<TQueue> {
+  processJobsOnQueues: (
+    queues: Record<string, TQueue>,
+    jobs: Record<string, Job>,
+    queueAdapter: QueueAdapter,
+  ) => void;
+}

--- a/src/jobs/processor/VoidQueueProcessor.ts
+++ b/src/jobs/processor/VoidQueueProcessor.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { getLoggerFor } from '../../logging/LogUtil';
+import type { QueueAdapter } from '../adapter/QueueAdapter';
+import type { Job } from '../Job';
+import type { QueueProcessor } from './QueueProcessor';
+
+export class VoidQueueProcessor implements QueueProcessor<any> {
+  protected readonly logger = getLoggerFor(this);
+
+  public processJobsOnQueues(
+    queues: Record<string, any>,
+    jobs: Record<string, Job>,
+    queueAdapter: QueueAdapter,
+  ): void {
+    // Do nothing
+  }
+}

--- a/test/integration/ConfiguredJobs.test.ts
+++ b/test/integration/ConfiguredJobs.test.ts
@@ -2,6 +2,7 @@
 import Bull from 'bull';
 import type { App } from '../../src/init/App';
 import { BullQueueAdapter } from '../../src/jobs/adapter/BullQueueAdapter';
+import { BullQueueProcessor } from '../../src/jobs/processor/BullQueueProcessor';
 import { getPort } from '../util/Util';
 import { getTestConfigPath, instantiateFromConfig, getDefaultVariables } from './Config';
 
@@ -49,6 +50,7 @@ describe('An http server with preconfigured jobs', (): void => {
           }),
         },
       },
+      queueProcessor: new BullQueueProcessor(),
       redisConfig,
     });
 

--- a/test/unit/jobs/processor/BullQueueProcessor.test.ts
+++ b/test/unit/jobs/processor/BullQueueProcessor.test.ts
@@ -1,0 +1,134 @@
+import type { Queue } from 'bull';
+import type { QueueAdapter } from '../../../../src/jobs/adapter/QueueAdapter';
+import type { Job } from '../../../../src/jobs/Job';
+import { BullQueueProcessor } from '../../../../src/jobs/processor/BullQueueProcessor';
+import type { Logger } from '../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../src/logging/LogUtil';
+
+jest.mock('../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { info: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+const logger: jest.Mocked<Logger> = getLoggerFor('StreamUtil') as any;
+
+describe('A BullQueueProcessor', (): void => {
+  let queues: Record<string, Queue>;
+  let perform: Job['perform'];
+  let job: Job;
+  let jobs: Record<string, Job>;
+  let process: any;
+  let add: any;
+  let on: any;
+  let processor: BullQueueProcessor;
+  let registeredJobs: Record<string, (data: any) => Promise<void>>;
+  let registeredEvents: Record<string, (...args: any[]) => void>;
+  let error: Error | undefined;
+  let stalled: boolean;
+  let adapter: QueueAdapter;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+
+    error = undefined;
+    stalled = false;
+    add = jest.fn().mockImplementation(
+      async(jobName: string, data: any, options: any): Promise<void> => {
+        if (!options.repeat && !options.delay) {
+          const jobDetails = { name: jobName };
+          registeredEvents.active(jobDetails);
+          if (error) {
+            registeredEvents.failed(jobDetails, error);
+            registeredEvents.error(error);
+          } else {
+            if (stalled) {
+              registeredEvents.stalled(jobDetails);
+            }
+            await registeredJobs[jobName]({ data });
+            registeredEvents.completed(jobDetails);
+          }
+        }
+      },
+    );
+
+    registeredJobs = {};
+    process = jest.fn().mockImplementation(
+      (jobName: string, concurrency: number, processFn: (bullJob: any) => Promise<void>): void => {
+        registeredJobs[jobName] = processFn;
+      },
+    );
+
+    registeredEvents = {};
+    on = jest.fn().mockImplementation((event: string, handler: () => void): void => {
+      registeredEvents[event] = handler;
+    });
+
+    queues = { default: { process, add, on, name: 'default' } as any };
+    perform = jest.fn();
+    job = { perform, options: { queue: 'default' }};
+    jobs = { example: job };
+
+    adapter = { } as any;
+    processor = new BullQueueProcessor();
+  });
+
+  it('initializes processing on the queues.', async(): Promise<void> => {
+    processor.processJobsOnQueues(queues, jobs, adapter);
+    expect(process).toHaveBeenCalledTimes(1);
+    expect(process.mock.calls[0][0]).toBe('example');
+    expect(process.mock.calls[0][1]).toBe(1);
+    expect(on).toHaveBeenCalledTimes(5);
+  });
+
+  it('initializes queues with only one total concurrent job.', async(): Promise<void> => {
+    jobs = { example: job, example2: job };
+    processor.processJobsOnQueues(queues, jobs, adapter);
+    expect(process).toHaveBeenCalledTimes(2);
+    expect(process.mock.calls[0][0]).toBe('example');
+    expect(process.mock.calls[0][1]).toBe(1);
+    expect(process.mock.calls[1][0]).toBe('example2');
+    expect(process.mock.calls[1][1]).toBe(0);
+    expect(on).toHaveBeenCalledTimes(5);
+  });
+
+  it('logs a message about a job starting then erroring.', async(): Promise<void> => {
+    error = new Error('Job failed');
+    processor.processJobsOnQueues(queues, jobs, adapter);
+    await queues.default.add('example', {}, {});
+    expect(process).toHaveBeenCalledTimes(1);
+    expect(process.mock.calls[0][0]).toBe('example');
+    expect(process.mock.calls[0][1]).toBe(1);
+    expect(on).toHaveBeenCalledTimes(5);
+    expect(logger.info).toHaveBeenCalledTimes(3);
+    expect(logger.info).toHaveBeenNthCalledWith(1, 'Job example has started on queue default');
+    expect(logger.info.mock.calls[1][0].startsWith('Job example on queue default failed with reason: Job failed'))
+      .toBe(true);
+    expect(logger.info.mock.calls[2][0].startsWith('An error occured in queue default: Job failed'))
+      .toBe(true);
+  });
+
+  it('logs a message about a job starting then completing.', async(): Promise<void> => {
+    processor.processJobsOnQueues(queues, jobs, adapter);
+    await queues.default.add('example', {}, {});
+    expect(process).toHaveBeenCalledTimes(1);
+    expect(process.mock.calls[0][0]).toBe('example');
+    expect(process.mock.calls[0][1]).toBe(1);
+    expect(on).toHaveBeenCalledTimes(5);
+    expect(logger.info).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenNthCalledWith(1, 'Job example has started on queue default');
+    expect(logger.info).toHaveBeenNthCalledWith(2, 'Job example successfully completed on queue default');
+  });
+
+  it('logs a message about a job starting then becoming stalled then completing.', async(): Promise<void> => {
+    stalled = true;
+    processor.processJobsOnQueues(queues, jobs, adapter);
+    await queues.default.add('example', {}, {});
+    expect(process).toHaveBeenCalledTimes(1);
+    expect(process.mock.calls[0][0]).toBe('example');
+    expect(process.mock.calls[0][1]).toBe(1);
+    expect(on).toHaveBeenCalledTimes(5);
+    expect(logger.info).toHaveBeenCalledTimes(3);
+    expect(logger.info).toHaveBeenNthCalledWith(1, 'Job example has started on queue default');
+    expect(logger.info).toHaveBeenNthCalledWith(2, 'Job example has been marked as stalled on queue default');
+    expect(logger.info).toHaveBeenNthCalledWith(3, 'Job example successfully completed on queue default');
+  });
+});

--- a/test/unit/jobs/processor/VoidQueueProcessor.test.ts
+++ b/test/unit/jobs/processor/VoidQueueProcessor.test.ts
@@ -1,0 +1,27 @@
+import type { Queue } from 'bull';
+import type { QueueAdapter } from '../../../../src/jobs/adapter/QueueAdapter';
+import type { Job } from '../../../../src/jobs/Job';
+import { VoidQueueProcessor } from '../../../../src/jobs/processor/VoidQueueProcessor';
+
+describe('A VoidQueueProcessor', (): void => {
+  let queues: Record<string, Queue>;
+  let perform: Job['perform'];
+  let job: Job;
+  let jobs: Record<string, Job>;
+  let processor: VoidQueueProcessor;
+  let adapter: QueueAdapter;
+
+  beforeEach(async(): Promise<void> => {
+    queues = { default: { name: 'default' } as any };
+    perform = jest.fn();
+    job = { perform, options: { queue: 'default' }};
+    jobs = { example: job };
+
+    adapter = { } as any;
+    processor = new VoidQueueProcessor();
+  });
+
+  it('does nothing.', async(): Promise<void> => {
+    expect(processor.processJobsOnQueues(queues, jobs, adapter)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- split queue processing out of queue adapter so that tasks can run and queue jobs without processing jobs on the queue