### PR TITLE
feat/json-errors

### DIFF
--- a/src/http/handler/ParsingHttpHandler.ts
+++ b/src/http/handler/ParsingHttpHandler.ts
@@ -57,7 +57,7 @@ export class ParsingHttpHandler extends HttpHandler {
       this.logger.verbose(`Parsed ${request.method} operation on ${request.url}`);
     } catch (error: unknown) {
       assertError(error);
-      result = await this.errorHandler.handleSafe({ error });
+      result = await this.errorHandler.handleSafe({ error, request, response });
     }
 
     if (result) {

--- a/src/http/output/error/ErrorHandler.ts
+++ b/src/http/output/error/ErrorHandler.ts
@@ -1,11 +1,12 @@
 import { AsyncHandler } from '../../../util/handlers/AsyncHandler';
+import type { HttpHandlerInput } from '../../handler/HttpHandler';
 import type { ResponseDescription } from '../response/ResponseDescription';
 
-export interface ErrorHandlerArgs {
+export interface ErrorHandlerInput extends HttpHandlerInput {
   error: Error;
 }
 
 /**
  * Converts an error into a {@link ResponseDescription} based on the request preferences.
  */
-export abstract class ErrorHandler extends AsyncHandler<ErrorHandlerArgs, ResponseDescription> {}
+export abstract class ErrorHandler extends AsyncHandler<ErrorHandlerInput, ResponseDescription> {}

--- a/src/http/output/error/RedirectingErrorHandler.ts
+++ b/src/http/output/error/RedirectingErrorHandler.ts
@@ -1,7 +1,7 @@
 import { NotImplementedHttpError } from '../../../util/errors/NotImplementedHttpError';
 import { RedirectHttpError } from '../../../util/errors/RedirectHttpError';
 import { ResponseDescription } from '../response/ResponseDescription';
-import type { ErrorHandlerArgs } from './ErrorHandler';
+import type { ErrorHandlerInput } from './ErrorHandler';
 import { ErrorHandler } from './ErrorHandler';
 
 /**
@@ -9,13 +9,13 @@ import { ErrorHandler } from './ErrorHandler';
  * This Error handler converts those to {@link ResponseDescription}s that are used for output.
  */
 export class RedirectingErrorHandler extends ErrorHandler {
-  public async canHandle({ error }: ErrorHandlerArgs): Promise<void> {
+  public async canHandle({ error }: ErrorHandlerInput): Promise<void> {
     if (!RedirectHttpError.isInstance(error)) {
       throw new NotImplementedHttpError('Only redirect errors are supported.');
     }
   }
 
-  public async handle({ error }: ErrorHandlerArgs): Promise<ResponseDescription> {
+  public async handle({ error }: ErrorHandlerInput): Promise<ResponseDescription> {
     // Cast verified by canHandle
     return new ResponseDescription((error as RedirectHttpError).statusCode);
   }

--- a/test/unit/http/handler/ParsingHttpHandler.test.ts
+++ b/test/unit/http/handler/ParsingHttpHandler.test.ts
@@ -61,7 +61,7 @@ describe('A ParsingHttpHandler', (): void => {
     requestHandler.handleSafe.mockRejectedValueOnce(error);
     await expect(handler.handle({ request, response })).resolves.toBeUndefined();
     expect(errorHandler.handleSafe).toHaveBeenCalledTimes(1);
-    expect(errorHandler.handleSafe).toHaveBeenLastCalledWith({ error });
+    expect(errorHandler.handleSafe).toHaveBeenLastCalledWith({ error, request: {}, response: {}});
     expect(responseWriter.handleSafe).toHaveBeenCalledTimes(1);
     expect(responseWriter.handleSafe).toHaveBeenLastCalledWith({ response, result: errorResponse });
   });
@@ -75,7 +75,7 @@ describe('A ParsingHttpHandler', (): void => {
     expect(requestParser.handleSafe).toHaveBeenCalledTimes(1);
     expect(requestParser.handleSafe).toHaveBeenLastCalledWith(request);
     expect(errorHandler.handleSafe).toHaveBeenCalledTimes(1);
-    expect(errorHandler.handleSafe).toHaveBeenLastCalledWith({ error });
+    expect(errorHandler.handleSafe).toHaveBeenLastCalledWith({ error, request: {}, response: {}});
     expect(responseWriter.handleSafe).toHaveBeenCalledTimes(1);
     expect(responseWriter.handleSafe).toHaveBeenLastCalledWith({ response, result: errorResponse });
   });

--- a/test/unit/http/output/error/RedirectingErrorHandler.test.ts
+++ b/test/unit/http/output/error/RedirectingErrorHandler.test.ts
@@ -1,3 +1,5 @@
+import type { HttpRequest } from '../../../../../src/http/HttpRequest';
+import type { HttpResponse } from '../../../../../src/http/HttpResponse';
 import { RedirectingErrorHandler } from '../../../../../src/http/output/error/RedirectingErrorHandler';
 import { BadRequestHttpError } from '../../../../../src/util/errors/BadRequestHttpError';
 import { FoundHttpError } from '../../../../../src/util/errors/FoundHttpError';
@@ -8,15 +10,27 @@ describe('A RedirectingErrorHandler', (): void => {
 
   it('only accepts redirect errors.', async(): Promise<void> => {
     const unsupportedError = new BadRequestHttpError();
-    await expect(handler.canHandle({ error: unsupportedError })).rejects.toThrow(NotImplementedHttpError);
+    await expect(handler.canHandle({
+      error: unsupportedError,
+      request: {} as HttpRequest,
+      response: {} as HttpResponse,
+    })).rejects.toThrow(NotImplementedHttpError);
 
     const supportedError = new FoundHttpError('http://test.com/foo/bar');
-    await expect(handler.canHandle({ error: supportedError })).resolves.toBeUndefined();
+    await expect(handler.canHandle({
+      error: supportedError,
+      request: {} as HttpRequest,
+      response: {} as HttpResponse,
+    })).resolves.toBeUndefined();
   });
 
   it('creates redirect responses.', async(): Promise<void> => {
     const error = new FoundHttpError('http://test.com/foo/bar');
-    const result = await handler.handle({ error });
+    const result = await handler.handle({
+      error,
+      request: {} as HttpRequest,
+      response: {} as HttpResponse,
+    });
     expect(result.statusCode).toBe(error.statusCode);
   });
 });

--- a/test/unit/http/output/error/SafeErrorHandler.test.ts
+++ b/test/unit/http/output/error/SafeErrorHandler.test.ts
@@ -1,13 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { HttpRequest } from '../../../../../src/http/HttpRequest';
+import type { HttpResponse } from '../../../../../src/http/HttpResponse';
 import type { ErrorHandler } from '../../../../../src/http/output/error/ErrorHandler';
 import { SafeErrorHandler } from '../../../../../src/http/output/error/SafeErrorHandler';
+import { APPLICATION_JSON } from '../../../../../src/util/ContentTypes';
 import { NotFoundHttpError } from '../../../../../src/util/errors/NotFoundHttpError';
-import { readableToString, guardedStreamFrom } from '../../../../../src/util/StreamUtil';
+import { readableToString, guardedStreamFrom, readJsonStream } from '../../../../../src/util/StreamUtil';
 
 describe('A SafeErrorHandler', (): void => {
   let error: Error;
   let stack: string | undefined;
   let errorHandler: jest.Mocked<ErrorHandler>;
   let handler: SafeErrorHandler;
+  let request: HttpRequest;
+  let response: HttpResponse;
 
   beforeEach(async(): Promise<void> => {
     error = new NotFoundHttpError('not here');
@@ -15,6 +21,18 @@ describe('A SafeErrorHandler', (): void => {
 
     errorHandler = {
       handleSafe: jest.fn().mockResolvedValue({ data: guardedStreamFrom('<html>fancy error</html>') }),
+    } as any;
+
+    request = {
+      headers: {
+        'content-type': 'text/plain',
+      },
+    } as any;
+
+    response = {
+      hasHeader: jest.fn(),
+      getHeader: jest.fn(),
+      setHeader: jest.fn(),
     } as any;
 
     handler = new SafeErrorHandler(errorHandler, true);
@@ -25,7 +43,11 @@ describe('A SafeErrorHandler', (): void => {
   });
 
   it('sends the request to the stored error handler.', async(): Promise<void> => {
-    const promise = handler.handle({ error } as any);
+    const promise = handler.handle({
+      error,
+      request,
+      response,
+    } as any);
     await expect(promise).resolves.toBeDefined();
     const result = await promise;
     await expect(readableToString(result.data!)).resolves.toBe('<html>fancy error</html>');
@@ -36,30 +58,112 @@ describe('A SafeErrorHandler', (): void => {
       errorHandler.handleSafe.mockRejectedValue(new Error('handler failed'));
     });
 
-    it('creates a text representation of the error.', async(): Promise<void> => {
-      const prom = handler.handle({ error } as any);
-      await expect(prom).resolves.toBeDefined();
-      const result = await prom;
-      expect(result.statusCode).toBe(404);
-      await expect(readableToString(result.data!)).resolves.toBe(`${stack}\n`);
+    describe('when the content-type header is not application/json', (): void => {
+      it('creates a text representation of the error.', async(): Promise<void> => {
+        const prom = handler.handle({
+          error,
+          request,
+          response,
+        } as any);
+        await expect(prom).resolves.toBeDefined();
+        const result = await prom;
+        expect(result.statusCode).toBe(404);
+        await expect(readableToString(result.data!)).resolves.toBe(`${stack}\n`);
+      });
+
+      it('concatenates name and message if there is no stack.', async(): Promise<void> => {
+        delete error.stack;
+        const prom = handler.handle({
+          error,
+          request,
+          response,
+        } as any);
+        await expect(prom).resolves.toBeDefined();
+        const result = await prom;
+        expect(result.statusCode).toBe(404);
+        await expect(readableToString(result.data!)).resolves.toBe(`NotFoundHttpError: not here\n`);
+      });
+
+      it('hides the stack trace if the option is disabled.', async(): Promise<void> => {
+        handler = new SafeErrorHandler(errorHandler);
+        const prom = handler.handle({
+          error,
+          request,
+          response,
+        } as any);
+        await expect(prom).resolves.toBeDefined();
+        const result = await prom;
+        expect(result.statusCode).toBe(404);
+        await expect(readableToString(result.data!)).resolves.toBe(`NotFoundHttpError: not here\n`);
+      });
     });
 
-    it('concatenates name and message if there is no stack.', async(): Promise<void> => {
-      delete error.stack;
-      const prom = handler.handle({ error } as any);
-      await expect(prom).resolves.toBeDefined();
-      const result = await prom;
-      expect(result.statusCode).toBe(404);
-      await expect(readableToString(result.data!)).resolves.toBe(`NotFoundHttpError: not here\n`);
-    });
+    describe('when the content-type header is application/json', (): void => {
+      beforeEach(async(): Promise<void> => {
+        request.headers['content-type'] = APPLICATION_JSON;
+      });
 
-    it('hides the stack trace if the option is disabled.', async(): Promise<void> => {
-      handler = new SafeErrorHandler(errorHandler);
-      const prom = handler.handle({ error } as any);
-      await expect(prom).resolves.toBeDefined();
-      const result = await prom;
-      expect(result.statusCode).toBe(404);
-      await expect(readableToString(result.data!)).resolves.toBe(`NotFoundHttpError: not here\n`);
+      it('creates a json representation of the error.', async(): Promise<void> => {
+        const prom = handler.handle({
+          error,
+          request,
+          response,
+        } as any);
+        await expect(prom).resolves.toBeDefined();
+        const result = await prom;
+        expect(result.statusCode).toBe(404);
+        await expect(readJsonStream(result.data!)).resolves.toMatchObject({
+          error: {
+            code: 404,
+            name: 'NotFoundHttpError',
+            message: stack,
+          },
+        });
+        expect(response.setHeader).toHaveBeenCalledTimes(1);
+        expect(response.setHeader).toHaveBeenCalledWith('Content-Type', APPLICATION_JSON);
+      });
+
+      it('shows the message if there is no stack.', async(): Promise<void> => {
+        delete error.stack;
+        const prom = handler.handle({
+          error,
+          request,
+          response,
+        } as any);
+        await expect(prom).resolves.toBeDefined();
+        const result = await prom;
+        expect(result.statusCode).toBe(404);
+        await expect(readJsonStream(result.data!)).resolves.toMatchObject({
+          error: {
+            code: 404,
+            name: 'NotFoundHttpError',
+            message: 'not here',
+          },
+        });
+        expect(response.setHeader).toHaveBeenCalledTimes(1);
+        expect(response.setHeader).toHaveBeenCalledWith('Content-Type', APPLICATION_JSON);
+      });
+
+      it('uses the message if the stack trace option is disabled.', async(): Promise<void> => {
+        handler = new SafeErrorHandler(errorHandler);
+        const prom = handler.handle({
+          error,
+          request,
+          response,
+        } as any);
+        await expect(prom).resolves.toBeDefined();
+        const result = await prom;
+        expect(result.statusCode).toBe(404);
+        await expect(readJsonStream(result.data!)).resolves.toMatchObject({
+          error: {
+            code: 404,
+            name: 'NotFoundHttpError',
+            message: 'not here',
+          },
+        });
+        expect(response.setHeader).toHaveBeenCalledTimes(1);
+        expect(response.setHeader).toHaveBeenCalledWith('Content-Type', APPLICATION_JSON);
+      });
     });
   });
 });


### PR DESCRIPTION
return errors as json when the content-type header is application/json